### PR TITLE
Create relative symlinks to autohook, at install

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -35,12 +35,11 @@ install() {
 
     repo_root=$(git rev-parse --show-toplevel)
     hooks_dir="$repo_root/.git/hooks"
-    autohook_filename="$repo_root/hooks/autohook.sh"
-    autohook_path=$(realpath $autohook_filename)
+    autohook_linktarget="../../hooks/autohook.sh"
     for hook_type in "${hook_types[@]}"
     do
         hook_symlink="$hooks_dir/$hook_type"
-        ln -s $autohook_path $hook_symlink
+        ln -s $autohook_linktarget $hook_symlink
     done
 }
 


### PR DESCRIPTION
## Which issues are addressed?

Using relative symlink targets instead of absolute ones. Helps if the whole git repo gets moved around in the filesystem (with absolute links, all symlinks are broken after such a move)
 
#4 is resolved as side-effect, since realpath isn't used anymore now.

## What's implemented?

Relative links from .git/hooks to autohook.sh (via ../../hooks/ path)


## Why this implementation?



## Any caveats?



## Any additional notes?



## Checklist

- [ ] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
