### PR TITLE
Capture exit code of executed scripts, pass failures out as git-hook …

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -71,13 +71,24 @@ main() {
         echo "Looking for $hook_type scripts to run...found $number_of_symlinks!"
         if [[ $number_of_symlinks -gt 0 ]]
         then
+            hook_exit_code=0
             for file in "${files[@]}"
             do
                 scriptname=$(basename $file)
                 echo "BEGIN $scriptname"
                 eval $file &> /dev/null
+                script_exit_code=$?
+                if [[ $script_exit_code != 0 ]]
+                then
+                  hook_exit_code=$script_exit_code
+                fi
                 echo "FINISH $scriptname"
             done
+            if [[ $hook_exit_code != 0 ]]
+            then
+              echo "A $hook_type script yielded negative exit code $hook_exit_code"
+              exit $hook_exit_code
+            fi
         fi
     fi
 }


### PR DESCRIPTION
…result

## Which issues are addressed?

autohook.sh currently swallows exit codes of the scripts it executes, and generally terminates with exit code 0 (success). In turn, git hooks which are specified to abort on failures (exit code != 0) never will actually abort.

## What's implemented?

If one or more of the scripts linked for a hook-type result in a negative (!= 0) exit code, that exit code will define the exit code of the whole hook (i.e. of the autohook.sh) invocation. By that way, a hook such as pre-commit is able to be aborted in case one of the sub-scripts defined via autohook fails.  


## Why this implementation?

Making sure to not swallow exit codes is crucial to maintain the basic functionality of git hooks, specifically for the pre-xxx hooks which should allow to act as a safeguard / prevent some operation. 

Either way, with this implementation, all of the sub-scripts for a hook-type still get executed, even if one has already failed at start. It would be possible to already abort on first failure instead though - however, since some of the hooks aren't even supposed to abort (post-xxx), IMO it's more consistent to still execute them all and only determine an appropriate total exit status as global result. 

## Any caveats?

In case there are multiple scripts for a hook type which fail, only one of their exit codes (the last one) will be used as exit code.  


## Any additional notes?



## Checklist

- [ ] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
