### PR TITLE
fix: make autohook work with modern userspace

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
 
 # Autohook
 # A very, very small Git hook manager with focus on automation
@@ -6,7 +6,12 @@
 # Version:        2.3.0
 # Website:        https://github.com/Autohook/Autohook
 
-debugging=1
+set -eu
+
+if [ "${AUTOHOOK_TRACE:-}" ]; then
+	set -x
+fi
+debugging="${AUTOHOOK_DEBUG:-0}"
 debug() {
   if [[ $debugging -ne 0 ]]; then
     builtin echo "[Autohook debug] $@" 1>&2
@@ -19,7 +24,7 @@ echo() {
 
 # Set up a temporary file and delete it automatically upon exit.
 
-if [[ "x$TMPDIR" = "x" ]]
+if [[ "x${TMPDIR:-}" = "x" ]]
 then
   export TMPDIR="/tmp"
 fi
@@ -139,7 +144,7 @@ main() {
     debug "    $hd"
   done
 
-  local -a files
+  local -a files=()
   for pdir in "${hook_dirs[@]}"; do
     dir="${pdir//\%/$hook_type}"
     debug "Looking for $hook_type hooks in $dir"

--- a/autohook.sh
+++ b/autohook.sh
@@ -24,7 +24,7 @@ echo() {
 
 # Set up a temporary file and delete it automatically upon exit.
 
-if [[ "x${TMPDIR:-}" = "x" ]]
+if [ -z "${TMPDIR:-}" ]
 then
   export TMPDIR="/tmp"
 fi


### PR DESCRIPTION
## Which issues are addressed?

Allows the script to run on Debian Trixie, likely fixes brokenness on other "modern" distributions.

## What's implemented?

- Move the bash options from the shebang line where there are portability issues to a `set` statement
  - At least with newer coreutils, such as is present in Debian trixie, the `env bash -eu` is an error and the script does not run at all. It requires a `-S` option to be passed to tell it to split the args on whitespace. Not sure how portable _that_ is, so just moving it to `set -eu` inside the script is simpler
- Fix several places where the script does not work if `-eu` is active
  - It seems like, on other platforms, the `-eu` in the shebang line was just ignored, because the script has many places where it will unconditionally fail in any version of bash if those options are active
- Disable debug output by default, allow control over that via environment variables
  - Having to edit the script to do debugging makes life difficult. Allow enabling the debug prints with `AUTOHOOK_DEBUG=1`, and allow turning on `set -x` for even more debugging via `AUTOHOOK_TRACE`

## Why this implementation?

It should run, reasonably portably.

## Any caveats?



## Any additional notes?



## Checklist

- [x] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
